### PR TITLE
Fixed the build after comm changes

### DIFF
--- a/team037/MapKnowledge.java
+++ b/team037/MapKnowledge.java
@@ -2,7 +2,7 @@ package team037;
 
 import battlecode.common.*;
 import team037.DataStructures.AppendOnlyMapLocationSet;
-import team037.Messages.Communication;
+import team037.Messages.MapBoundsCommunication;
 import team037.Utilites.MapUtils;
 
 public class MapKnowledge {
@@ -54,44 +54,44 @@ public class MapKnowledge {
     }
 
 
-    public Communication packForMessage() {
-        Communication communication = new Communication();
+    public MapBoundsCommunication packForMessage() {
+        MapBoundsCommunication communication = new MapBoundsCommunication();
 
         if (minX != Integer.MIN_VALUE && maxX != Integer.MIN_VALUE) {
-            communication.val1 = 3;
-            communication.loc1X = minX + MAP_ADD;
-            communication.val2 = maxX - minX;
+            communication.widthIndicator = 3;
+            communication.xVal = minX + MAP_ADD;
+            communication.width = maxX - minX;
         } else if (minX != Integer.MIN_VALUE) {
-            communication.val1 = 2;
-            communication.loc1X = minX + MAP_ADD;
-            communication.val2 = 0;
+            communication.widthIndicator = 2;
+            communication.xVal = minX + MAP_ADD;
+            communication.width = 0;
         } else if (maxX != Integer.MIN_VALUE) {
-            communication.val1 = 1;
-            communication.loc1X = maxX + MAP_ADD;
-            communication.val2 = 0;
+            communication.widthIndicator = 1;
+            communication.xVal = maxX + MAP_ADD;
+            communication.width = 0;
         } else {
-            communication.val1 = 0;
-            communication.loc1X = 0;
-            communication.val2 = 0;
+            communication.widthIndicator = 0;
+            communication.xVal = 0;
+            communication.width = 0;
         }
 
 
         if (minY != Integer.MIN_VALUE && maxY != Integer.MIN_VALUE) {
-            communication.val2 = 3;
-            communication.loc1Y = minY + MAP_ADD;
-            communication.val4 = maxY - minY;
+            communication.heightIndicator = 3;
+            communication.yVal = minY + MAP_ADD;
+            communication.height = maxY - minY;
         } else if (minY != Integer.MIN_VALUE) {
-            communication.val2 = 2;
-            communication.loc1Y = minY + MAP_ADD;
-            communication.val4 = 0;
+            communication.heightIndicator = 2;
+            communication.yVal = minY + MAP_ADD;
+            communication.height = 0;
         } else if (maxY != Integer.MIN_VALUE) {
-            communication.val2 = 1;
-            communication.loc1Y = maxY + MAP_ADD;
-            communication.val4 = 0;
+            communication.heightIndicator = 1;
+            communication.yVal = maxY + MAP_ADD;
+            communication.height = 0;
         } else {
-            communication.val2 = 0;
-            communication.loc1Y = 0;
-            communication.val4 = 0;
+            communication.heightIndicator = 0;
+            communication.yVal = 0;
+            communication.height = 0;
         }
 
         return communication;
@@ -114,14 +114,14 @@ public class MapKnowledge {
         }
     }
 
-    public void updateEdgesFromMessage(Communication communication) {
-        int widthBit = communication.val1;
-        int xCoord = communication.loc1X;
-        int width = communication.val2;
+    public void updateEdgesFromMessage(MapBoundsCommunication communication) {
+        int widthBit = communication.widthIndicator;
+        int xCoord = communication.xVal;
+        int width = communication.width;
 
-        int heightBit = communication.val3;
-        int yCoord = communication.loc1Y;
-        int height = communication.val4;
+        int heightBit = communication.heightIndicator;
+        int yCoord = communication.yVal;
+        int height = communication.height;
 
 
         if (widthBit == 0) {

--- a/team037/Messages/MapBoundsCommunication.java
+++ b/team037/Messages/MapBoundsCommunication.java
@@ -8,38 +8,55 @@ import team037.Utilites.CommunicationUtilities;
  */
 public class MapBoundsCommunication extends Communication
 {
-    int widthIndicator;
-    int minX;
-    int width;
-    int heightIndicator;
-    int minY;
-    int height;
+    public int widthIndicator;
+    public int xVal;
+    public int width;
+    public int heightIndicator;
+    public int yVal;
+    public int height;
+
+    public MapBoundsCommunication() {
+        super();
+        opcode = CommunicationType.MAP_BOUNDS;
+    }
 
     @Override
     public int[] getValues()
     {
-        return new int[]{CommunicationType.toInt(opcode), widthIndicator, minX, width,
-        heightIndicator, minY, height};
+        return new int[]{
+                CommunicationType.toInt(opcode),
+                widthIndicator,
+                xVal,
+                width,
+                heightIndicator,
+                yVal,
+                height
+        };
     }
 
     @Override
     public void setValues(int[] values)
     {
-        opcode = CommunicationType.fromInt(values[0]);
-        widthIndicator = values[1];
-        minX = values[2];
-        width = values[3];
-        heightIndicator = values[4];
-        minY = values[5];
-        height = values[6];
+        opcode = CommunicationType.MAP_BOUNDS;
+        widthIndicator = values[0];
+        xVal = values[1];
+        width = values[2];
+        heightIndicator = values[3];
+        yVal = values[4];
+        height = values[5];
     }
 
     @Override
     public int[] getLengths()
     {
-        return new int[]{CommunicationUtilities.opcodeSize, CommunicationUtilities.mapIndicatorSize,
-        CommunicationUtilities.locationSize, CommunicationUtilities.mapSpanSize,
-        CommunicationUtilities.mapIndicatorSize, CommunicationUtilities.locationSize,
-        CommunicationUtilities.mapSpanSize};
+        return new int[]{
+            CommunicationUtilities.opcodeSize,
+            CommunicationUtilities.mapIndicatorSize,
+            CommunicationUtilities.locationSize,
+            CommunicationUtilities.mapSpanSize,
+            CommunicationUtilities.mapIndicatorSize,
+            CommunicationUtilities.locationSize,
+            CommunicationUtilities.mapSpanSize
+        };
     }
 }


### PR DESCRIPTION
@joshatron needed to update this after changing the build.

I think setting via enabling public access to the fields is the way to go, much more intuitive than passing in ints.

In addition we KNOW the opcode of the message when we create it, so I moved that to the constructor.
