### PR TITLE
Fixed up heal code to only heal allies in attack range

### DIFF
--- a/team037/Units/BaseArchon.java
+++ b/team037/Units/BaseArchon.java
@@ -77,9 +77,7 @@ public class BaseArchon extends Unit
     // maybe spawn a unit or repair a damaged unit
     public boolean carryOutAbility() throws GameActionException
     {
-        if (healNearbyAllies()) {
-            return true;
-        }
+        healNearbyAllies();
 
         if (neutralBots.length > 0)
         {


### PR DESCRIPTION
Current code will throw errors if the archon tries to heal someone it can see that isn't in attack range.

also pulled out the heal behavior so inherited classes could use it
